### PR TITLE
Add timeouts= to the adapter

### DIFF
--- a/lib/dns_adapter/mock_client.rb
+++ b/lib/dns_adapter/mock_client.rb
@@ -42,6 +42,10 @@ module DNSAdapter
       fetch_records(domain, 'SPF')
     end
 
+    def timeouts=(timeouts)
+      # Deliberate NOOP
+    end
+
     def fetch_records(domain, type)
       record_set = find_records_for_domain(domain)
       return [] if record_set.empty?

--- a/lib/dns_adapter/resolv_client.rb
+++ b/lib/dns_adapter/resolv_client.rb
@@ -42,6 +42,10 @@ module DNSAdapter
       fetch_name_records(domain, 'CNAME')
     end
 
+    def timeouts=(timeouts)
+      dns_resolver.timeouts = timeouts
+    end
+
     private
 
     def fetch_a_type_records(domain, type)

--- a/spec/resolv_client_spec.rb
+++ b/spec/resolv_client_spec.rb
@@ -487,4 +487,13 @@ describe DNSAdapter::ResolvClient do
         .to raise_error(DNSAdapter::TimeoutError)
     end
   end
+
+  context '#timeouts=' do
+    let(:timeout_val) { 5 }
+    it 'should delegate timeouts=' do
+      expect(Resolv::DNS).to receive(:new).and_return(mock_resolver)
+      expect(mock_resolver).to receive(:timeouts=).with(timeout_val)
+      expect { subject.timeouts = timeout_val }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Add timeouts= to the adapter, so we can set timeout behavior for the underlying ResolvClient