### PR TITLE
Code review on project specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
           path: tmp/test-results/rspec/results.xml
           if-no-files-found: ignore
 
+      - name: Upload SimpleCov HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: simplecov-html-ruby-${{ matrix.ruby-version }}
+          path: coverage/
+          if-no-files-found: ignore
+
       - name: Report code coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,3 +4,5 @@
 * Support to Ruby 4.0
 * CI migrated from Circle to Github
 * Adding Changelog.md
+# README review
+* Review on project specs

--- a/lib/dns_adapter/mock_client.rb
+++ b/lib/dns_adapter/mock_client.rb
@@ -61,23 +61,27 @@ module DNSAdapter
       return nil if type == 'CNAME' # Never follow CNAME for a CNAME query
 
       cname_record = formatted_records(records_for_type(record_set, 'CNAME'), 'CNAME').first
-      cname_target = cname_record.try(:[], :name)
-      cname_target.present? ? raw_records(cname_target, type) : nil
+      cname_target = cname_record&.[](:name)
+      blank?(cname_target) ? nil : raw_records(cname_target, type)
     end
 
     private
 
     def normalize_domain(domain)
-      return if domain.blank?
+      return if blank?(domain)
 
       domain = domain[0...-1] if domain[-1] == '.'
       domain.downcase
     end
 
     def find_records_for_domain(domain)
-      return [] if domain.blank?
+      return [] if blank?(domain)
 
       @zone_data[normalize_domain(domain)] || []
+    end
+
+    def blank?(value)
+      value.nil? || value.empty?
     end
 
     def records_for_type(record_set, type)

--- a/spec/dns_adapter/mock_client_spec.rb
+++ b/spec/dns_adapter/mock_client_spec.rb
@@ -1,7 +1,153 @@
 require 'spec_helper'
 
-# rubocop:disable RSpec/EmptyExampleGroup
 describe DNSAdapter::MockClient do
-  # Deliberately empty because we don't test the mock.
+  subject(:client) { described_class.new(zone_data) }
+
+  let(:zone_data) do
+    {
+      'Direct.EXAMPLE.COM' => [
+        { 'A' => '192.0.2.1' },
+        { 'AAAA' => '2001:db8::1' },
+        { 'MX' => [10, 'mail.example.com'] },
+        { 'MX' => ['mail-only.example.com'] },
+        { 'NS' => 'ns1.example.com' },
+        { 'TXT' => ['v=spf1 ', '-all'] },
+        { 'SPF' => ['v=spf1 ', '~all'] },
+        { 'A' => 'NONE' },
+        { 'SOA' => 'ns1.example.com' },
+        'not a record'
+      ],
+      'example.com' => [
+        { 'CNAME' => 'target.example.com' }
+      ],
+      'target.example.com' => [
+        { 'A' => '198.51.100.1' },
+        { 'TXT' => 'target text' }
+      ],
+      '4.3.2.1.in-addr.arpa' => [
+        { 'PTR' => 'ptr.example.com' }
+      ],
+      'timeout.example.com' => [
+        described_class::TIMEOUT
+      ],
+      'record-timeout.example.com' => [
+        { 'A' => described_class::TIMEOUT }
+      ]
+    }
+  end
+
+  describe '#fetch_a_records' do
+    it 'normalizes case and trailing dots before returning A records' do
+      expect(client.fetch_a_records('DIRECT.EXAMPLE.COM.')).to contain_exactly(
+        { type: 'A', address: '192.0.2.1' }
+      )
+    end
+
+    it 'follows CNAME records for address lookups' do
+      expect(client.fetch_a_records('example.com')).to contain_exactly(
+        { type: 'A', address: '198.51.100.1' }
+      )
+    end
+  end
+
+  describe '#fetch_aaaa_records' do
+    it 'returns AAAA records with address values' do
+      expect(client.fetch_aaaa_records('direct.example.com')).to contain_exactly(
+        { type: 'AAAA', address: '2001:db8::1' }
+      )
+    end
+  end
+
+  describe '#fetch_mx_records' do
+    it 'returns MX records with preference values when provided' do
+      expect(client.fetch_mx_records('direct.example.com')).to contain_exactly(
+        { type: 'MX', preference: 10, exchange: 'mail.example.com' },
+        { type: 'MX', exchange: 'mail-only.example.com' }
+      )
+    end
+  end
+
+  describe '#fetch_ns_records' do
+    it 'returns NS records with name values' do
+      expect(client.fetch_ns_records('direct.example.com')).to contain_exactly(
+        { type: 'NS', name: 'ns1.example.com' }
+      )
+    end
+  end
+
+  describe '#fetch_cname_records' do
+    it 'returns CNAME records without following them' do
+      expect(client.fetch_cname_records('example.com')).to contain_exactly(
+        { type: 'CNAME', name: 'target.example.com' }
+      )
+    end
+  end
+
+  describe '#fetch_txt_records' do
+    it 'joins TXT record segments' do
+      expect(client.fetch_txt_records('direct.example.com')).to contain_exactly(
+        { type: 'TXT', text: 'v=spf1 -all' }
+      )
+    end
+  end
+
+  describe '#fetch_spf_records' do
+    it 'joins SPF record segments' do
+      expect(client.fetch_spf_records('direct.example.com')).to contain_exactly(
+        { type: 'SPF', text: 'v=spf1 ~all' }
+      )
+    end
+  end
+
+  describe '#fetch_ptr_records' do
+    it 'returns PTR records with name values' do
+      expect(client.fetch_ptr_records('4.3.2.1.in-addr.arpa')).to contain_exactly(
+        { type: 'PTR', name: 'ptr.example.com' }
+      )
+    end
+  end
+
+  describe '#fetch_records' do
+    it 'returns an empty array when the domain is blank' do
+      expect(client.fetch_records('', 'A')).to eq([])
+    end
+
+    it 'returns an empty array when the domain is nil' do
+      expect(client.fetch_records(nil, 'A')).to eq([])
+    end
+
+    it 'returns an empty array when the domain has no records' do
+      expect(client.fetch_records('missing.example.com', 'A')).to eq([])
+    end
+
+    it 'raises a timeout error for a domain timeout marker' do
+      expect { client.fetch_records('timeout.example.com', 'A') }
+        .to raise_error(DNSAdapter::TimeoutError)
+    end
+
+    it 'raises a timeout error for a record timeout marker' do
+      expect { client.fetch_records('record-timeout.example.com', 'A') }
+        .to raise_error(DNSAdapter::TimeoutError)
+    end
+  end
+
+  describe '#raw_records' do
+    it 'returns raw matching records without formatting them' do
+      expect(client.raw_records('direct.example.com', 'NS')).to contain_exactly(
+        { 'NS' => 'ns1.example.com' }
+      )
+    end
+  end
+
+  describe '#normalize_domain' do
+    it 'returns nil when the domain is nil' do
+      expect(client.send(:normalize_domain, nil)).to be_nil
+    end
+  end
+
+  describe '#timeouts=' do
+    it 'accepts timeout assignments without changing behavior' do
+      expect { client.timeouts = 5 }.not_to raise_error
+    end
+  end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/dns_adapter/resolv_client_spec.rb
+++ b/spec/dns_adapter/resolv_client_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe 'DNSAdapter' do
+  describe DNSAdapter::ResolvClient do
+    describe '.type_class' do
+      it 'raises an argument error for unknown record types' do
+        expect { described_class.type_class('CAA') }
+          .to raise_error(ArgumentError, 'Unknown RR type: CAA')
+      end
+    end
+  end
+
   shared_examples 'a ResolvClient' do |klass|
     subject(:client) { klass.new }
 
@@ -10,7 +19,7 @@ describe 'DNSAdapter' do
       allow(Resolv::DNS).to receive(:new).and_return(mock_resolver)
     end
 
-    describe "##fetch_a_records from #{klass.name}" do
+    describe "#fetch_a_records for #{klass.name}" do
       let(:first_a_addr) { Resolv::IPv4.new([127, 0, 0, 1].pack('CCCC')) }
       let(:first_a_record) { Resolv::DNS::Resource::IN::A.new(first_a_addr) }
       let(:second_a_addr) { Resolv::IPv4.new([192, 168, 8, 14].pack('CCCC')) }
@@ -19,7 +28,7 @@ describe 'DNSAdapter' do
       let(:domain) { 'example.com' }
       let(:domain_with_trailing) { "#{domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::A).and_return(record_list)
 
@@ -32,7 +41,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:address).map(&:to_s))
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::A).and_return(record_list)
 
@@ -45,7 +54,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:address).map(&:to_s))
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::A)
           .and_raise(Resolv::ResolvError)
@@ -55,7 +64,7 @@ describe 'DNSAdapter' do
         end.to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::A)
           .and_raise(Resolv::ResolvTimeout)
@@ -65,7 +74,7 @@ describe 'DNSAdapter' do
         end.to raise_error(DNSAdapter::TimeoutError)
       end
 
-      it 'maps the nil responses to Coppertone errors' do
+      it 'translates nil responses to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::A)
           .and_return(nil)
@@ -93,7 +102,7 @@ describe 'DNSAdapter' do
       let(:domain) { 'example.com' }
       let(:domain_with_trailing) { "#{domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::AAAA).and_return(record_list)
 
@@ -106,7 +115,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:address).map(&:to_s))
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::AAAA).and_return(record_list)
 
@@ -119,7 +128,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:address).map(&:to_s))
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::AAAA)
           .and_raise(Resolv::ResolvError)
@@ -128,7 +137,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::AAAA)
           .and_raise(Resolv::ResolvTimeout)
@@ -155,7 +164,7 @@ describe 'DNSAdapter' do
       let(:domain) { 'example.com' }
       let(:domain_with_trailing) { "#{domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::MX).and_return(record_list)
 
@@ -168,7 +177,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:exchange).map(&:to_s))
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::MX).and_return(record_list)
 
@@ -181,7 +190,7 @@ describe 'DNSAdapter' do
           .to eq(record_list.map(&:exchange).map(&:to_s))
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::MX)
           .and_raise(Resolv::ResolvError)
@@ -190,7 +199,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::MX)
           .and_raise(Resolv::ResolvTimeout)
@@ -209,7 +218,7 @@ describe 'DNSAdapter' do
       let(:arpa_domain) { '126.18.67.80.in-addr.arpa' }
       let(:arpa_domain_with_trailing) { "#{arpa_domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(arpa_domain, Resolv::DNS::Resource::IN::PTR)
           .and_return(record_list)
@@ -224,7 +233,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(arpa_domain, Resolv::DNS::Resource::IN::PTR)
           .and_return(record_list)
@@ -239,7 +248,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(arpa_domain, Resolv::DNS::Resource::IN::PTR)
           .and_raise(Resolv::ResolvError)
@@ -248,7 +257,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(arpa_domain, Resolv::DNS::Resource::IN::PTR)
           .and_raise(Resolv::ResolvTimeout)
@@ -275,7 +284,7 @@ describe 'DNSAdapter' do
       let(:domain) { 'example.com' }
       let(:domain_with_trailing) { "#{domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::TXT)
           .and_return(record_list)
@@ -291,7 +300,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::TXT)
           .and_return(record_list)
@@ -307,7 +316,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::TXT)
           .and_raise(Resolv::ResolvError)
@@ -316,7 +325,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::TXT)
           .and_raise(Resolv::ResolvTimeout)
@@ -343,7 +352,7 @@ describe 'DNSAdapter' do
       let(:domain) { 'example.com' }
       let(:domain_with_trailing) { "#{domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::SPF)
           .and_return(record_list)
@@ -359,7 +368,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::SPF)
           .and_return(record_list)
@@ -375,7 +384,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::SPF)
           .and_raise(Resolv::ResolvError)
@@ -384,7 +393,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(domain, Resolv::DNS::Resource::IN::SPF)
           .and_raise(Resolv::ResolvTimeout)
@@ -403,7 +412,7 @@ describe 'DNSAdapter' do
       let(:ns_domain) { 'example.com' }
       let(:ns_domain_with_trailing) { "#{ns_domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(ns_domain, Resolv::DNS::Resource::IN::NS)
           .and_return(record_list)
@@ -418,7 +427,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(ns_domain, Resolv::DNS::Resource::IN::NS)
           .and_return(record_list)
@@ -433,7 +442,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(ns_domain, Resolv::DNS::Resource::IN::NS)
           .and_raise(Resolv::ResolvError)
@@ -442,7 +451,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(ns_domain, Resolv::DNS::Resource::IN::NS)
           .and_raise(Resolv::ResolvTimeout)
@@ -461,7 +470,7 @@ describe 'DNSAdapter' do
       let(:cname_domain) { 'example.com' }
       let(:cname_domain_with_trailing) { "#{cname_domain}." }
 
-      it 'maps the Resolv classes to a set of hashes' do
+      it 'maps Resolv records to hashes' do
         expect(mock_resolver).to receive(:getresources)
           .with(cname_domain, Resolv::DNS::Resource::IN::CNAME)
           .and_return(record_list)
@@ -476,7 +485,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps when the domain has a trailing dot' do
+      it 'normalizes domains with trailing dots' do
         expect(mock_resolver).to receive(:getresources)
           .with(cname_domain, Resolv::DNS::Resource::IN::CNAME)
           .and_return(record_list)
@@ -491,7 +500,7 @@ describe 'DNSAdapter' do
         )
       end
 
-      it 'maps the Resolv errors to Coppertone errors' do
+      it 'translates Resolv errors to DNSAdapter errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(cname_domain, Resolv::DNS::Resource::IN::CNAME)
           .and_raise(Resolv::ResolvError)
@@ -500,7 +509,7 @@ describe 'DNSAdapter' do
           .to raise_error(DNSAdapter::Error)
       end
 
-      it 'maps the Resolv timeout errors to Coppertone errors' do
+      it 'translates Resolv timeout errors to DNSAdapter timeout errors' do
         expect(mock_resolver).to receive(:getresources)
           .with(cname_domain, Resolv::DNS::Resource::IN::CNAME)
           .and_raise(Resolv::ResolvTimeout)
@@ -513,7 +522,7 @@ describe 'DNSAdapter' do
     describe '#timeouts=' do
       let(:timeout_val) { 5 }
 
-      it 'delegates timeouts=' do
+      it 'delegates timeout assignments to the resolver' do
         expect(mock_resolver).to receive(:timeouts=).with(timeout_val)
         expect { client.timeouts = timeout_val }.not_to raise_error
       end

--- a/spec/dns_adapter/resolv_ns_client_spec.rb
+++ b/spec/dns_adapter/resolv_ns_client_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe DNSAdapter::ResolvNsClient do
+  describe '#dns_resolver' do
+    it 'builds a resolver that uses Cloudflare nameservers without search domains' do
+      resolver = instance_double(Resolv::DNS)
+
+      expect(Resolv::DNS).to receive(:new).with(
+        nameserver: DNSAdapter::CLIENT_NAMESERVERS,
+        search: [],
+        ndots: 1
+      ).and_return(resolver)
+
+      expect(described_class.new.send(:dns_resolver)).to eq(resolver)
+    end
+  end
+end

--- a/spec/resolv/dns/resource/in/spf_spec.rb
+++ b/spec/resolv/dns/resource/in/spf_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Resolv::DNS::Resource::IN::SPF do
+  it 'uses the DNS SPF resource type value' do
+    expect(described_class::TypeValue).to eq(99)
+  end
+
+  it 'inherits TXT record behavior' do
+    record = described_class.new('v=spf1 ', '-all')
+
+    expect(record.strings).to eq(['v=spf1 ', '-all'])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,10 @@ require 'simplecov'
 
 if ENV['CODECOV_TOKEN']
   require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Codecov
+  ]
 end
 
 SimpleCov.start do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,11 @@ if ENV['CODECOV_TOKEN']
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
-SimpleCov.start
+SimpleCov.start do
+  enable_coverage :branch
+  track_files 'lib/**/*.rb'
+  add_filter '/spec/'
+end
 
 require 'dns_adapter'
 


### PR DESCRIPTION
## Summary

- Replaced the empty `DNSAdapter::MockClient` spec with focused unit coverage for record formatting, CNAME handling, blank/missing domains, timeout paths, and raw record behavior.
- Added coverage for previously untested branches/files, including `ResolvClient.type_class`, `ResolvNsClient`, and the SPF resource class.
- Fixed `MockClient` usage outside ActiveSupport by replacing `blank?`, `present?`, and `try` calls with Ruby-native logic.
- Cleaned up spec descriptions for clearer grammar and removed stale “Coppertone” wording.
- Added SimpleCov HTML report support in CI
